### PR TITLE
Increase height of non-bsuit human

### DIFF
--- a/configs/classes/human_light.model.cfg
+++ b/configs/classes/human_light.model.cfg
@@ -6,7 +6,7 @@ shadowScale       1.0
 hud               human_hud
 
 mins              -15 -15 -24
-maxs              15 15 32
+maxs              15 15 35
 crouchMaxs        15 15 16
 deadMins          -15 -15 -4
 deadMaxs          15 15 4

--- a/configs/classes/human_medium.model.cfg
+++ b/configs/classes/human_medium.model.cfg
@@ -6,7 +6,7 @@ shadowScale       1.0
 hud               human_hud
 
 mins              -15 -15 -24
-maxs              15 15 32
+maxs              15 15 35
 crouchMaxs        15 15 16
 deadMins          -15 -15 -4
 deadMaxs          15 15 4

--- a/configs/classes/human_naked.model.cfg
+++ b/configs/classes/human_naked.model.cfg
@@ -6,7 +6,7 @@ shadowScale       1.0
 hud               human_hud
 
 mins              -15 -15 -24
-maxs              15 15 32
+maxs              15 15 35
 crouchMaxs        15 15 16
 deadMins          -15 -15 -4
 deadMaxs          15 15 4


### PR DESCRIPTION
At the current height the head sticks out of the bbox a bit when standing still, and even more when walking. With the new height the head is fully contained when still and pops out a little bit when walking.

The screenshots show the model without the proposed change.

![unvanquished_2023-08-26_165852_000](https://github.com/UnvanquishedAssets/res-players_src.dpkdir/assets/7809431/3a1f7391-193a-4600-bc3f-0bc24e4c1dbd)
![unvanquished_2023-08-26_165857_000](https://github.com/UnvanquishedAssets/res-players_src.dpkdir/assets/7809431/2c58209c-45a8-46db-8f61-80d676e3a325)
