### PR TITLE
Fix 'green_acid' shader culling

### DIFF
--- a/scripts/alien_base.shader
+++ b/scripts/alien_base.shader
@@ -1,5 +1,6 @@
 gfx/players/alien_base/green_acid
 {
+	cull none
 	nopicmip
 	{
 		clampmap gfx/players/alien_base/green_acid


### PR DESCRIPTION
Fixes invisible acid effect particles produced on alien evolve and alien buildable bleeding or destruction.

Particle shaders are expected to disable back-faced triangle culling but this shader lacked it. Combined with a long-standing bug of drawing sprite entity triangle with a backwards orientation, this made the particles invisible.

The evolve effect looks like this:
![unvanquished_2024-09-24_010714_000](https://github.com/user-attachments/assets/b63a84de-2c0e-43ea-8158-e0a129ebd74f)

